### PR TITLE
Имя снепшота не может заканчиваться на символ "-"

### DIFF
--- a/models.go
+++ b/models.go
@@ -44,7 +44,7 @@ type MessageQueueEvent struct {
 type CreateSnapshotParams struct {
 	FolderId string `json:"folderId"`
 	DiskId   string `json:"diskId"`
-	DiskName   string `json:"diskName"`
+	DiskName string `json:"diskName"`
 }
 
 type Response struct {

--- a/spawn-snapshot-tasks.go
+++ b/spawn-snapshot-tasks.go
@@ -74,10 +74,16 @@ func SpawnHandler(ctx context.Context) (*Response, error) {
 			continue
 		}
 
+		// Если у диска не задано в настройках имя, используем для генерации имени снимка идентификатор диска
+		diskName := d.Name
+		if diskName == "" {
+			diskName = d.Id
+		}
+
 		params := constructDiskMessage(CreateSnapshotParams{
 			FolderId: folderId,
 			DiskId:   d.Id,
-			DiskName: d.Name,
+			DiskName: diskName,
 		}, &queueUrl)
 		// Отправляем в Yandex Message Queue сообщение с праметрами какой диск нужно снепшотить
 		_, err = svc.SendMessage(params)


### PR DESCRIPTION
Исправление https://github.com/nikolaymatrosov/go-yc-serverless-snapshot/issues/4

1. Если не задано имя диска, используем вместо него идентификатор этого диска для генерации имени снепшота
2. После проверки на максимальную длину также проверяем что он не заканчивается на запрещённый символ дефиса ("-") и при необходимости вырезаем 
